### PR TITLE
Make yamllint happy

### DIFF
--- a/charts/meteor-pipelines/values.yaml
+++ b/charts/meteor-pipelines/values.yaml
@@ -13,7 +13,7 @@ pypi:
   username: sesheta
   password: password
 
-eventlisteners: # we only support GitHub ATM
+eventlisteners:  # we only support GitHub ATM
   - thoth-station:
       github:
         webhooksecret: lameGitHubWebhookSecretToken


### PR DESCRIPTION
Add an additional space before a comment in `values.yaml` to make `yamllint` accept the file.

This is to address https://github.com/thoth-station/helm-charts/pull/9#issuecomment-984174685